### PR TITLE
 fix sveltekit compatibility and add missing focus prop

### DIFF
--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -66,6 +66,9 @@
   export let selection = null;
   export let value = null;
   export let labelAsValue = false;
+  export const focus = event => {
+    refControl.focusControl(event);
+  };
   export const getSelection = onlyValues => {
     if (!selection) return multiple ? [] : null;
     return multiple 

--- a/src/components/Dropdown.svelte
+++ b/src/components/Dropdown.svelte
@@ -127,7 +127,7 @@
     scrollContainer.style = '';
   }
 
-  let dropdownStateSubscription; 
+  let dropdownStateSubscription = () => {};
   /** ************************************ lifecycle */
   onMount(() => {
     /** ************************************ flawless UX related tweak */

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -50,10 +50,9 @@ export function debounce(fn, delay) {
 	};
 };
 
-const itemHtml = document.createElement('div');
-itemHtml.className = 'sv-item-content';
-
 export function highlightSearch(item, isSelected, $inputValue, formatter) {
+  const itemHtml = document.createElement('div');
+  itemHtml.className = 'sv-item-content';
   itemHtml.innerHTML = formatter ? formatter(item, isSelected) : item;
   if ($inputValue == '' || item.isSelected) return itemHtml.outerHTML;
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -51,11 +51,13 @@ export function debounce(fn, delay) {
 };
 
 export function highlightSearch(item, isSelected, $inputValue, formatter) {
-  const itemHtml = document.createElement('div');
-  itemHtml.className = 'sv-item-content';
-  itemHtml.innerHTML = formatter ? formatter(item, isSelected) : item;
-  if ($inputValue == '' || item.isSelected) return itemHtml.outerHTML;
+  const itemHtmlText = '<div class="sv-item-content">'
+    + (formatter ? formatter(item, isSelected) : item)
+    + '</div>';
+  if ($inputValue == '' || item.isSelected) return itemHtmlText;
 
+  const itemHtml = makeElement(itemHtmlText);
+  
   // const regex = new RegExp(`(${asciifold($inputValue)})`, 'ig');
   const pattern = asciifold($inputValue);
   pattern.split(' ').filter(e => e).forEach(pat => {
@@ -63,6 +65,12 @@ export function highlightSearch(item, isSelected, $inputValue, formatter) {
   });
   
   return itemHtml.outerHTML;
+}
+
+function makeElement(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.firstChild;
 }
 
 /**

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -60,7 +60,7 @@ export function highlightSearch(item, isSelected, $inputValue, formatter) {
 
   if (!itemHtml) {
     const div = document.createElement('div');
-    div.innerHTML = html;
+    div.innerHTML = itemHtmlText;
     itemHtml = div.firstChild;
   }
   

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -50,13 +50,19 @@ export function debounce(fn, delay) {
 	};
 };
 
+let itemHtml;
+
 export function highlightSearch(item, isSelected, $inputValue, formatter) {
   const itemHtmlText = '<div class="sv-item-content">'
     + (formatter ? formatter(item, isSelected) : item)
     + '</div>';
   if ($inputValue == '' || item.isSelected) return itemHtmlText;
 
-  const itemHtml = makeElement(itemHtmlText);
+  if (!itemHtml) {
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    itemHtml = div.firstChild;
+  }
   
   // const regex = new RegExp(`(${asciifold($inputValue)})`, 'ig');
   const pattern = asciifold($inputValue);
@@ -65,12 +71,6 @@ export function highlightSearch(item, isSelected, $inputValue, formatter) {
   });
   
   return itemHtml.outerHTML;
-}
-
-function makeElement(html) {
-  const div = document.createElement('div');
-  div.innerHTML = html;
-  return div.firstChild;
 }
 
 /**


### PR DESCRIPTION
This pull request fixes two issues I ran across when using Svelecte in SvelteKit:

* The reference to `document` in global scope in `src/lib/utils.js` breaks SSR because the document global is only available in the browser. The easy fix is to move the code into `highlightSearch`.
* The docs mention a `focus` function exposed as a prop but it was not implemented, so I added it. Fixes #12 

I'm fine with using my forked version for now, but I thought it might be useful to incorporate these fixes.