### PR TITLE
add `disableFilter` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ vlHeight          | number           | `null`     | Height of virtual list dropd
 vlItemSize        | number           | `null`     | Height of one row (if not specified, computed automatically)
 searchField       | string\|array    | `null`     | Specify item property that will be used to search by (if not specified all props except `value` prop will be used)
 sortField         | string           | `null`     | Specify sort property. If not specified, `labelField` will be used 
-disableSifter     | bool             | `false`    | Disable option sifting and accept all fetched options.
+disableSifter     | bool             | `false`    | Disable option sifting and accept all fetched options
 class             | string           | `'svelecte-control'` | default css class
 style             | string           | null       | inline style
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ creatable         | bool             | `false`    | Allow creating new item(s)
 creatablePrefix   | string           | `'*'`      | Prefix marking new item
 delimiter         | string           | `','`      | split inserted text when pasting to create multiple items
 fetch             | string\|function | `null`     | Check "remote datasource" section for more details
-fetch             | string           | `'auto'`   | When set to `init` options are fetched only when mounted, when searching it search in downloaded dataset
+fetchMode         | string           | `'auto'`   | When set to `init` options are fetched only when mounted, when searching it search in downloaded dataset
 fetchCallback     | function         | `null`     | optional fetch callback
 lazyDropdown      | bool             | `true`     | render dropdown after first focus, not by default
 virtualList       | bool             | `false`    | Whether use virtual list for dropdown items (useful for large datasets)
@@ -62,7 +62,7 @@ vlHeight          | number           | `null`     | Height of virtual list dropd
 vlItemSize        | number           | `null`     | Height of one row (if not specified, computed automatically)
 searchField       | string\|array    | `null`     | Specify item property that will be used to search by (if not specified all props except `value` prop will be used)
 sortField         | string           | `null`     | Specify sort property. If not specified, `labelField` will be used 
-disableSifter     | bool             | `false`    | Disable option sifting and accept all fetched options
+disableSifter     | bool             | `false`    | Disable Sifter filtering & sorting. Can be useful in combination with `fetch`, when no further filtering or sorting may be undesired
 class             | string           | `'svelecte-control'` | default css class
 style             | string           | null       | inline style
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ vlHeight          | number           | `null`     | Height of virtual list dropd
 vlItemSize        | number           | `null`     | Height of one row (if not specified, computed automatically)
 searchField       | string\|array    | `null`     | Specify item property that will be used to search by (if not specified all props except `value` prop will be used)
 sortField         | string           | `null`     | Specify sort property. If not specified, `labelField` will be used 
+disableSifter     | bool             | `false`    | Disable option sifting and accept all fetched options.
 class             | string           | `'svelecte-control'` | default css class
 style             | string           | null       | inline style
 

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -162,7 +162,6 @@
         xhr.abort();
       };
       if (!value) {
-        listMessage = config.i18n.fetchBefore;
         return;
       }
       isFetchingData = true;
@@ -207,7 +206,9 @@
     ? config.i18n.max(max)
     : ($inputValue.length && availableItems.length === 0
       ? config.i18n.nomatch 
-      : config.i18n.empty
+      : fetch
+        ? config.i18n.fetchBefore
+        : config.i18n.empty
     );
   $: itemRenderer = typeof renderer === 'function' ? renderer : (formatterList[renderer] || formatterList.default.bind({ label: currentLabelField}));
   $: {

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -60,7 +60,7 @@
   // sifter related
   export let searchField = null;
   export let sortField = null;
-  export let disableFilter = false;
+  export let disableSifter = false;
   // styling
   let className = 'svelecte-control';
   export { className as class};
@@ -193,7 +193,7 @@
   $: maxReached = max && selectedOptions.size === max 
   $: availableItems = maxReached
     ? []
-    : filterList(flatItems, disableFilter ? null : $inputValue, multiple, searchField, sortField, itemConfig);
+    : filterList(flatItems, disableSifter ? null : $inputValue, multiple, searchField, sortField, itemConfig);
   $: currentListLength = creatable && $inputValue ? availableItems.length : availableItems.length - 1;
   $: listIndex = indexList(availableItems, creatable && $inputValue, itemConfig);
   $: {

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -60,6 +60,7 @@
   // sifter related
   export let searchField = null;
   export let sortField = null;
+  export let disableFilter = false;
   // styling
   let className = 'svelecte-control';
   export { className as class};
@@ -190,7 +191,9 @@
   let alreadyCreated = [];
   $: flatItems = flatList(options, itemConfig);
   $: maxReached = max && selectedOptions.size === max 
-  $: availableItems = maxReached ? [] : filterList(flatItems, $inputValue, multiple, searchField, sortField, itemConfig);
+  $: availableItems = maxReached
+    ? []
+    : filterList(flatItems, disableFilter ? null : $inputValue, multiple, searchField, sortField, itemConfig);
   $: currentListLength = creatable && $inputValue ? availableItems.length : availableItems.length - 1;
   $: listIndex = indexList(availableItems, creatable && $inputValue, itemConfig);
   $: {

--- a/src/settings.js
+++ b/src/settings.js
@@ -24,8 +24,6 @@ const settings = {
   virtualList: false,
   vlItemSize: null,
   vlHeight: null,
-  // sifter
-  sortRemoteResults: true,
   // i18n
   i18n: {
     empty: 'No options',


### PR DESCRIPTION
This pull request adds a new `disableFilter` prop on the Svelecte component. When `true`, it disables filtering of options with the sifter in `filterList` and simply returns all of the options. This is useful in the case where the options are fetched remotely and it makes sense to filter them on the server side (for example because the dataset is large or the matching algorithm is complex). It's otherwise not really possible to achieve this functionality, as far as I can tell.

The patch is very simple but it seems to work well in my testing so far. The only strange behavior I found is that when you unfocus the input and refocus it, the dropdown reappears even with the now-empty input box, which is a bit odd for when the suggestions are correlated with the typed input. Possible fixes to deal with this would be:

* Add another new prop to control whether the input is cleared in `onBlur`, so there is an option not to do so.
* Expose an API to clear the option list, in case the desired behavior is the current default of clearing the input. For this to be useful, you might also have to dispatch an event for when the input is cleared.

There are a couple other loose ends I ran into:

* When the component has just been mounted and the input is focused, the dropdown appears with the "No options" message. Not very friendly for someone who hasn't had a chance to type anything yet!
* `highlightSearch` is very nice for the default case but there may be times you want to override it, for example when using a custom formatter that outputs text that happens to match the search string. (Simple example: imagine a custom formatter matching the value "Nathan" and outputting "Name: Nathan, Country: Germany". `highlightSearch` would erroneously highlight the "Na" in "Name".) To improve this, I suggest adding a prop `disableHighlight` and also passing `$inputValue` to custom formatters in case they want to handle the highlighting.

If you think any of these ideas are good, I can probably implement some of them before you merge anything. But I wanted to discuss it first because it goes well beyond the relatively simple change in this pull request.

By the way, feel free to rename any of these props in case you think there's a better name!