### PR TITLE
fix: add role to element

### DIFF
--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -604,7 +604,7 @@
   });
 </script>
 
-<div class={`svelecte ${className}`} class:is-disabled={disabled} {style}>
+<div class={`svelecte ${className}`} class:is-disabled={disabled} {style} role="combobox">
   <Control bind:this={refControl} renderer={itemRenderer}
     {disabled} {clearable} {searchable} {placeholder} {multiple} {inputId} {resetOnBlur} collapseSelection={collapseSelection ? config.collapseSelectionFn : null}
     inputValue={inputValue} hasFocus={hasFocus} hasDropdownOpened={hasDropdownOpened} selectedOptions={selectedOptions} {isFetchingData}

--- a/src/components/Dropdown.svelte
+++ b/src/components/Dropdown.svelte
@@ -167,7 +167,7 @@
   on:mousedown|preventDefault
 >
   <div class="sv-dropdown-scroll" class:is-empty={!items.length}  bind:this={scrollContainer}>
-    <div class="sv-dropdown-content" bind:this={container} class:max-reached={maxReached}>
+    <div role="listbox" class="sv-dropdown-content" bind:this={container} class:max-reached={maxReached}>
     {#if items.length}
       {#if virtualList}
         <VirtualList bind:this={refVirtualList}
@@ -180,6 +180,7 @@
         >
           <div slot="item" let:index let:style {style}
             class="sv-dd-item"
+            role="option"
             class:sv-dd-item-active={index == dropdownIndex}
             class:sv-group-item={items[index].$isGroupItem}
             class:sv-group-header={items[index].$isGroupHeader}
@@ -201,6 +202,7 @@
             class:sv-dd-item-active={listIndex.map[i] == dropdownIndex}
             class:sv-group-item={opt.$isGroupItem}
             class:sv-group-header={opt.$isGroupHeader}
+            role="option"
           >
             <svelte:component this={itemComponent} formatter={renderer}
               index={listIndex.map[i]}


### PR DESCRIPTION
I"ve added some role attribute for better a11y. For now, It miss `aria-activedescendant` which reference child's id 
I'm not sure on how to add the correct `id` on items and reference the active id  (focus / hover) on the `input` if you have any advice I can update the PR 