### PR TITLE
feat: add slot at the end of the Control.svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ const myI18n = {
 <Svelecte i18n={myI18n}></Svelecte>
 ```
 
+## Customizable Slots
+
+There are different slots within the component that allow to insert custom code and icons.
+
+### Control.svelte (bubbled up to the Svelecte component)
+- ```icon``` This allows to insert custom code like e.g. an icon at the start/left of the Control.svelte
+- ```control-end``` This allows to insert custom code at the end/right of the Control.svelte. It is positioned AFTER the indicator icons.
+
 ## 🙏 Thanks to
 
 - [selectize.js](https://github.com/selectize/selectize.js) - inspiration

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -665,6 +665,7 @@
     on:blur
   >
     <div slot="icon" class="icon-slot"><slot name="icon"></slot></div>
+    <div slot="control-end"><slot name="control-end"></slot></div>
   </Control>
   <Dropdown bind:this={refDropdown} renderer={itemRenderer} {disableHighlight} {creatable} {maxReached} {alreadyCreated}
     {virtualList} {vlHeight} {vlItemSize} lazyDropdown={virtualList || lazyDropdown} {multiple}

--- a/src/components/Control.svelte
+++ b/src/components/Control.svelte
@@ -42,12 +42,12 @@
 
   /** ************************************ context */
   const dispatch = createEventDispatcher();
-  
+
   let doCollapse = true;
   let refInput = undefined;
 
   function onFocus() {
-    $hasFocus = true; 
+    $hasFocus = true;
     $hasDropdownOpened = true;
     setTimeout(() => {
     doCollapse = false;
@@ -113,10 +113,11 @@
       </svg>
     </div>
   </div>
+  <slot name="control-end"></slot>
 </div>
 
 <style>
-.sv-control { 
+.sv-control {
   background-color: var(--sv-bg);
   border: var(--sv-border);
   border-radius: 4px;


### PR DESCRIPTION
Hi :)
This is more of a feature, which makes the UI a little more adaptable. I added a slot at the end of the Control.svelte component because this allows  to also put an icon or a small button or something at the end of the component.

In my special case, this would come in handy, because I would like to have a button at the end of the field which allows to call my functions and direct to other parts of the UI.
For example like so:
![image](https://user-images.githubusercontent.com/57353201/209171128-aea7cbc4-33de-4651-97f5-b3a489e3270f.png)

Would be kind of you to have look and merge if it's okay, thx
