### PR TITLE
feat: add slot and flag to be able to toggle the clear icon, such that for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ There are different slots within the component that allow to insert custom code 
 ### Control.svelte (bubbled up to the Svelecte component)
 - ```icon``` This allows to insert custom code like e.g. an icon at the start/left of the Control.svelte
 - ```control-end``` This allows to insert custom code at the end/right of the Control.svelte. It is positioned AFTER the indicator icons.
+- ```icon-toggle-clear``` When ```clearable = true``` and ```toggleIcon = true```, we can insert an icon, like e.g. magnifying glasses, that is showing when 
+  no input is given. As soon as there is any input, we see the X-icon that allows to clear the input. This essentially means that we have switching 
+  icons depending if the input is empty or not.
 
 ## 🙏 Thanks to
 

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -45,6 +45,7 @@
   // UI, UX
   export let searchable = defaults.searchable;
   export let clearable = defaults.clearable;
+  export let toggleClearIcon = defaults.toggleClearIcon;
   export let renderer = null;
   export let disableHighlight = false;
   export let selectOnTab = defaults.selectOnTab;
@@ -653,7 +654,8 @@
 
 <div class={`svelecte ${className}`} class:is-disabled={disabled} {style}>
   <Control bind:this={refControl} renderer={itemRenderer}
-    {disabled} {clearable} {searchable} {placeholder} {multiple} inputId={inputId || __id} {resetOnBlur} collapseSelection={collapseSelection ? config.collapseSelectionFn.bind(_i18n): null}
+    {disabled} {clearable} {toggleClearIcon} {searchable} {placeholder} {multiple} inputId={inputId || __id} {resetOnBlur}
+           collapseSelection={collapseSelection ? config.collapseSelectionFn.bind(_i18n): null}
     inputValue={inputValue} hasFocus={hasFocus} hasDropdownOpened={hasDropdownOpened} selectedOptions={selectedOptions} {isFetchingData}
     {dndzone} {currentValueField} {isAndroid}
     itemComponent={controlItem}
@@ -666,6 +668,7 @@
   >
     <div slot="icon" class="icon-slot"><slot name="icon"></slot></div>
     <div slot="control-end"><slot name="control-end"></slot></div>
+    <div slot="icon-toggle-clear"><slot name="icon-toggle-clear"></slot></div> <!-- in addition to filling this slot, we need to give toggleClearIcon = true -->
   </Control>
   <Dropdown bind:this={refDropdown} renderer={itemRenderer} {disableHighlight} {creatable} {maxReached} {alreadyCreated}
     {virtualList} {vlHeight} {vlItemSize} lazyDropdown={virtualList || lazyDropdown} {multiple}

--- a/src/components/Control.svelte
+++ b/src/components/Control.svelte
@@ -4,6 +4,7 @@
   import Input from './Input.svelte';
 
   export let clearable;
+  export let toggleClearIcon;
   export let searchable;
   export let renderer;
   export let disabled;
@@ -96,13 +97,18 @@
   </div>
   <!-- buttons, indicators -->
   <div class="indicator" class:is-loading={isFetchingData} >
-    {#if clearable && selectedOptions.length && !disabled}
+    {#if clearable && !disabled}
+      {#if toggleClearIcon && !selectedOptions.length}
+        <div aria-hidden="true">
+          <slot name="icon-toggle-clear"></slot> <!-- this slot allows to insert another <svg> or <img> and not only image by given src -->
+        </div>
+        {:else if selectedOptions.length}
     <div aria-hidden="true" class="indicator-container close-icon"
       on:mousedown|preventDefault
-      on:click={() => dispatch('deselect')}
-    >
+      on:click={() => dispatch('deselect')}>
       <svg class="indicator-icon" height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg>
     </div>
+      {/if}
     {/if}
     {#if clearable}
     <span class="indicator-separator"></span>

--- a/src/settings.js
+++ b/src/settings.js
@@ -12,6 +12,7 @@ const settings = {
   // ui
   searchable: true,
   clearable: false,
+  toggleClearIcon: false,
   selectOnTab: false,
   resetOnBlur: true,
   resetOnSelect: true,


### PR DESCRIPTION
…empty input one can see that icon and for given input we see the x icon to clear the input

I want to be able to see a magnifying glass/lens instead of the x icon when there is no input. As soon as the user gives any input, i would like to see the x again to be able to clear the input.
Therefore, I created a flag which enables this as well as added a slot such that one can input any `<img>` or `<svg>` tag or the like. Further, the slot allows to attach a function to the toggleIcon such that I can e.g. trigger a search functionality or so.