### PR TITLE
feat: Slots for customizing indicator and clear icons

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -349,10 +349,12 @@
             <div class="column col-lg-12 col-xl-6 col-6">
               <h4>&bull; Slots &bull;</h4>
               <div id="example-5" class="example-wrap"></div>
-              <p class="mt-2"><code>Control</code> component provides 2 slots.
+              <p class="mt-2"><code>Control</code> component provides 4 slots.
               <ul>
                 <li><code>icon</code> - This allows to insert custom code like e.g. an icon at the start/left of the Control.svelte (as shown in the example above)</li>
                 <li><code>control-end</code> - This allows to insert custom code at the end/right of the Control.svelte. It is positioned AFTER the indicator icons.</li>
+                <li><code>indicator-icon</code> - This allows to customize the indicator icon in the Control.svelte. Slot has <code>hasDropdownOpened</code> property that helps customizing different control states.</li>
+                <li><code>clear-icon</code> - This allows to customize the clear icon in the Control.svelte.</li>
               </ul>
             </div>
             <div class="column col-lg-12 col-xl-6 col-6">

--- a/docs/index.html
+++ b/docs/index.html
@@ -354,7 +354,7 @@
                 <li><code>icon</code> - This allows to insert custom code like e.g. an icon at the start/left of the Control.svelte (as shown in the example above)</li>
                 <li><code>control-end</code> - This allows to insert custom code at the end/right of the Control.svelte. It is positioned AFTER the indicator icons.</li>
                 <li><code>indicator-icon</code> - This allows to customize the indicator icon in the Control.svelte. Slot has <code>hasDropdownOpened</code> property that helps customizing different control states.</li>
-                <li><code>clear-icon</code> - This allows to customize the clear icon in the Control.svelte.</li>
+                <li><code>clear-icon</code> - This allows to customize the clear icon in the Control.svelte. Slot has <code>selectedOptions</code> and <code>inputValue</code> properties for fine-grained customization</li>
               </ul>
             </div>
             <div class="column col-lg-12 col-xl-6 col-6">

--- a/docs/src/05-slot.svelte
+++ b/docs/src/05-slot.svelte
@@ -12,8 +12,10 @@
 
 <Svelecte options={options} 
   bind:value={iconValue}
-  placeholder="Pick your color, even the black 😉"
+  clearable
+  placeholder="Pick your color, even the black. Try to type to see 'clearable' icon change"
 >
   <b slot="icon">{iconSlot}</b>
+  <svelte:fragment slot="clear-icon" let:selectedOptions let:inputValue>{selectedOptions.length ? '❌' : inputValue ? '👀' : '❓' }</svelte:fragment>
   <svelte:fragment slot="indicator-icon" let:hasDropdownOpened>{hasDropdownOpened?'😃':'😄'}</svelte:fragment>
 </Svelecte>

--- a/docs/src/05-slot.svelte
+++ b/docs/src/05-slot.svelte
@@ -15,4 +15,5 @@
   placeholder="Pick your color, even the black 😉"
 >
   <b slot="icon">{iconSlot}</b>
+  <svelte:fragment slot="indicator-icon" let:hasDropdownOpened>{hasDropdownOpened?'😃':'😄'}</svelte:fragment>
 </Svelecte>

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -677,6 +677,14 @@
   >
     <div slot="icon" class="icon-slot"><slot name="icon"></slot></div>
     <div slot="control-end"><slot name="control-end"></slot></div>
+    <slot name="indicator-icon" slot="indicator-icon" let:hasDropdownOpened {hasDropdownOpened}>
+      <svg width="20" height="20" class="indicator-icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+        <path d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"></path>
+      </svg>
+    </slot>
+    <slot name="clear-icon" slot="clear-icon">
+      <svg class="indicator-icon" height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg>
+    </slot>
   </Control>
   <Dropdown bind:this={refDropdown} renderer={itemRenderer} {disableHighlight} {creatable} {maxReached} {alreadyCreated}
     {virtualList} {vlHeight} {vlItemSize} lazyDropdown={virtualList || lazyDropdown} {multiple}

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -682,8 +682,10 @@
         <path d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"></path>
       </svg>
     </slot>
-    <slot name="clear-icon" slot="clear-icon">
+    <slot name="clear-icon" slot="clear-icon" {selectedOptions} inputValue={$inputValue}>
+      {#if selectedOptions.length}
       <svg class="indicator-icon" height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg>
+      {/if}
     </slot>
   </Control>
   <Dropdown bind:this={refDropdown} renderer={itemRenderer} {disableHighlight} {creatable} {maxReached} {alreadyCreated}
@@ -779,5 +781,12 @@
   :global(.svelecte-control .highlight) {
     background-color: var(--sv-highlight-bg);
     color: var(--sv-highlight-color, var(--sv-color));
+  }
+  .indicator-icon {
+    display: inline-block;
+    fill: currentcolor;
+    line-height: 1;
+    stroke: currentcolor;
+    stroke-width: 0px;
   }
 </style>

--- a/src/components/Control.svelte
+++ b/src/components/Control.svelte
@@ -101,16 +101,20 @@
       on:mousedown|preventDefault
       on:click={() => dispatch('deselect')}
     >
-      <svg class="indicator-icon" height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg>
+      <slot name="clear-icon">
+        <svg class="indicator-icon" height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg>
+      </slot>
     </div>
     {/if}
     {#if clearable}
     <span class="indicator-separator"></span>
     {/if}
     <div aria-hidden="true" class="indicator-container" on:mousedown|preventDefault>
-      <svg width="20" height="20" class="indicator-icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-        <path d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"></path>
-      </svg>
+      <slot name="indicator-icon" hasDropdownOpened={$hasDropdownOpened}>
+        <svg width="20" height="20" class="indicator-icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+          <path d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"></path>
+        </svg>
+      </slot>
     </div>
   </div>
   <slot name="control-end"></slot>

--- a/src/components/Control.svelte
+++ b/src/components/Control.svelte
@@ -96,13 +96,15 @@
   </div>
   <!-- buttons, indicators -->
   <div class="indicator" class:is-loading={isFetchingData} >
-    {#if clearable && selectedOptions.length && !disabled}
+    {#if clearable && !disabled}
     <div aria-hidden="true" class="indicator-container close-icon"
       on:mousedown|preventDefault
       on:click={() => dispatch('deselect')}
     >
       <slot name="clear-icon">
+        <!-- {#if !inputValue && selectedOptions.length} -->
         <svg class="indicator-icon" height="20" width="20" viewBox="0 0 20 20" aria-hidden="true" focusable="false"><path d="M14.348 14.849c-0.469 0.469-1.229 0.469-1.697 0l-2.651-3.030-2.651 3.029c-0.469 0.469-1.229 0.469-1.697 0-0.469-0.469-0.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-0.469-0.469-0.469-1.228 0-1.697s1.228-0.469 1.697 0l2.652 3.031 2.651-3.031c0.469-0.469 1.228-0.469 1.697 0s0.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c0.469 0.469 0.469 1.229 0 1.698z"></path></svg>
+        <!-- {/if} -->
       </slot>
     </div>
     {/if}
@@ -183,7 +185,7 @@
   width: 1px;
   box-sizing: border-box;
 }
-.indicator-icon {
+:global(.indicator-icon) {
   display: inline-block;
   fill: currentcolor;
   line-height: 1;


### PR DESCRIPTION
I was using Svelecte in combination with the other UI components library and discovered that it is impossible to change the looks of the indicator icon to match styles. 

This pull request adds two slots (the second is for the clear icon) to help with this problem. 
The indicator icon slot also has a property to differentiate between open and closed states.