### PR TITLE
Add prop `highlightFirstItem`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ disabled          | bool             | `false`    | Disable component
 renderer          | string\|function | `null`     | dropdown and selection renderer function. More info in item rendering section
 controlItem       | Component        | `Item`     | Item component when item is selected. See [Custom Items](#custom-items) section for more details.
 dropdownItem      | Component        | `Item`     | Item component in dropdown. See [Custom Items](#custom-items) section for more details.
+highlightFirstItem| bool             | `true`     | Automatically highlight the first item in list when the dropdown opens.
 selectOnTab       | bool|string|null | `null`     | Based on value provided, it allows selecting currently active item by <kbd>Tab</kbd> AND (if value is `'select-navigate'`) also focus next input. The constant `TAB_SELECT_NAVIGATE` is exported from svelecte
 resetOnBlur       | bool             | `true`     | Control if input value should be cleared on blur
 resetOnSelect     | bool             | `true`     | Control if input value should be cleared on item selection. **Note:** applicable only with `multiple` 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ disabled          | bool             | `false`    | Disable component
 renderer          | string\|function | `null`     | dropdown and selection renderer function. More info in item rendering section
 controlItem       | Component        | `Item`     | Item component when item is selected. See [Custom Items](#custom-items) section for more details.
 dropdownItem      | Component        | `Item`     | Item component in dropdown. See [Custom Items](#custom-items) section for more details.
-highlightFirstItem| bool             | `true`     | Automatically highlight the first item in list when the dropdown opens.
+highlightFirstItem| bool             | `true`     | Automatically highlight the first item in the list when the dropdown opens
 selectOnTab       | bool|string|null | `null`     | Based on value provided, it allows selecting currently active item by <kbd>Tab</kbd> AND (if value is `'select-navigate'`) also focus next input. The constant `TAB_SELECT_NAVIGATE` is exported from svelecte
 resetOnBlur       | bool             | `true`     | Control if input value should be cleared on blur
 resetOnSelect     | bool             | `true`     | Control if input value should be cleared on item selection. **Note:** applicable only with `multiple` 

--- a/docs/index.html
+++ b/docs/index.html
@@ -762,6 +762,12 @@ const OPTION_LIST = [
                 <td>Item component when item is selected. See <a href="https://github.com/mskocik/svelecte#custom-items" target="github">README section</a> on GitHub for more details</td>
               </tr>
               <tr>
+                <td>highlightFirstItem</td>
+                <td>boolean</td>
+                <td><code>true</code></td>
+                <td>Automatically highlight the first item in the list when the dropdown opens</td>
+              </tr>
+              <tr>
                 <td>selectOnTab</td>
                 <td>bool|string|null</td>
                 <td><code>null</code></td>

--- a/src/Svelecte.svelte
+++ b/src/Svelecte.svelte
@@ -48,6 +48,7 @@
   export let clearable = defaults.clearable;
   export let renderer = null;
   export let disableHighlight = false;
+  export let highlightFirstItem = defaults.highlightFirstItem;
   export let selectOnTab = defaults.selectOnTab;
   export let resetOnBlur = defaults.resetOnBlur;
   export let resetOnSelect = defaults.resetOnSelect;
@@ -275,7 +276,7 @@
   $: currentListLength = creatable && $inputValue ? availableItems.length : availableItems.length - 1;
   $: listIndex = indexList(availableItems, creatable && $inputValue, itemConfig);
   $: {
-    if (dropdownActiveIndex === null) {
+    if (dropdownActiveIndex === null && (highlightFirstItem || $inputValue)) {
       dropdownActiveIndex = listIndex.first;
     } else if (dropdownActiveIndex > listIndex.last) {
       dropdownActiveIndex = listIndex.last;
@@ -533,6 +534,9 @@
         event.preventDefault();
         if (!$hasDropdownOpened) {
           $hasDropdownOpened = true;
+          if (dropdownActiveIndex === null) {
+            dropdownActiveIndex = listIndex.first
+          }
           return;
         }
         dropdownActiveIndex = listIndex.prev(dropdownActiveIndex);
@@ -553,9 +557,12 @@
         event.preventDefault();
         if (!$hasDropdownOpened) {
           $hasDropdownOpened = true;
+          if (dropdownActiveIndex === null) {
+            dropdownActiveIndex = listIndex.first
+          }
           return;
         }
-        dropdownActiveIndex = listIndex.next(dropdownActiveIndex);
+        dropdownActiveIndex = dropdownActiveIndex === null ? listIndex.first : listIndex.next(dropdownActiveIndex);
         tick().then(refDropdown.scrollIntoView);
         ignoreHover = true;
         break;
@@ -652,7 +659,6 @@
       const valueProp = itemConfig.labelAsValue ? currentLabelField : currentValueField;
       alreadyCreated = [''].concat(flatItems.map(opt => opt[valueProp]).filter(opt => opt));
     }
-    dropdownActiveIndex = listIndex.first;
     if (prevValue && !multiple) {
       const prop = labelAsValue ? currentLabelField : currentValueField;
       const selectedProp = valueAsObject ? prevValue[prop] : prevValue;

--- a/src/settings.js
+++ b/src/settings.js
@@ -12,6 +12,7 @@ const settings = {
   // ui
   searchable: true,
   clearable: false,
+  highlightFirstItem: true,
   selectOnTab: null,        // recognize values: null, truthy, 'select-navigate'
   resetOnBlur: true,
   resetOnSelect: true,


### PR DESCRIPTION
This PR adds a prop `highlightFirstItem` to the Svelecte component.  
When set to `true` (the default), the current behavior of the component isn't changed.  
When set to `false`, no item is initially highlighted in the dropdown when the component gets focus. This allows for easier keyboard (_Tab_) navigation by preventing accidental item selection when the user just wants to "pass" the Svelecte input without selecting anything.

The two keyboard event cases `ArrowUp` and `ArrowDown` get the following addition to address a side effect where, when the dropdown is opened with these keys, the first item wouldn't be highlighted (if `highlightFirstItem` is `false`) as expected with the current behavior:

```js
if (dropdownActiveIndex === null) {
  dropdownActiveIndex = listIndex.first
}
```

It would be nice to have the `dropdownActiveIndex` set to `null` if `highlightFirstItem` is `false` and the input field is empty (basically, when the user erases their current search text to get back to the "initial" state: empty input when the component just gets focus), but I think this would require a lot more changes; not sure if you are willing to make such changes for this feature.

Closes #162.