### PR TITLE
Add filterSelections and hideSelections options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ closeAfterSelect  | bool             | `false`    | closes dropdown after select
 max               | number           | `0`        | Maximum allowed items selected, applicable only for multiselect
 collapseSelection | bool             | `false`    | collapse selection when `multiple` and not focused
 alwaysCollapsed   | bool             | `false`    | keep collapsed selection _even_ when focused. Selected options are shown in dropdown on the top
+filterSelections  | bool             | `true`     | Whether to filter selected items from the available list or not
 inputId           | string           | `null`     | allow targeting input using a html label.
 creatable         | bool             | `false`    | Allow creating new item(s)
 creatablePrefix   | string           | `*`        | Prefix marking new item

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ max               | number           | `0`        | Maximum allowed items select
 collapseSelection | bool             | `false`    | collapse selection when `multiple` and not focused
 alwaysCollapsed   | bool             | `false`    | keep collapsed selection _even_ when focused. Selected options are shown in dropdown on the top
 filterSelections  | bool             | `true`     | Whether to filter selected items from the available list or not
+hideSelections    | bool             | `false`    | Hides the section with selected items from the dropdown
 inputId           | string           | `null`     | allow targeting input using a html label.
 creatable         | bool             | `false`    | Allow creating new item(s)
 creatablePrefix   | string           | `*`        | Prefix marking new item

--- a/docs/index.html
+++ b/docs/index.html
@@ -829,6 +829,12 @@ const OPTION_LIST = [
                 <td>Whether to filter selected items from the available list or not.</td>
               </tr>
               <tr>
+                <td>hideSelections</td>
+                <td>bool</td>
+                <td><code>false</code></td>
+                <td>works only when <code>alwaysCollapsed</code> is <code>true</code>. Hides the section with selected items from the dropdowns.</td>
+              </tr>
+              <tr>
                 <td>anchor</td>
                 <td>string</td>
                 <td><code>null</code></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -823,6 +823,12 @@ const OPTION_LIST = [
                 <td>works only when <code>collapseSelection</code> is <code>true</code>. It shows only collapsed selection in input line. Options themselves are shown in dropdown.</td>
               </tr>
               <tr>
+                <td>filterSelections</td>
+                <td>bool</td>
+                <td><code>true</code></td>
+                <td>Whether to filter selected items from the available list or not.</td>
+              </tr>
+              <tr>
                 <td>anchor</td>
                 <td>string</td>
                 <td><code>null</code></td>

--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -62,6 +62,7 @@
   export let max = defaults.max;
   export let collapseSelection = defaults.collapseSelection;
   export let alwaysCollapsed = defaults.alwaysCollapsed;
+  export let filterSelections = defaults.filterSelections;
   // creating
   export let creatable = defaults.creatable;
   export let creatablePrefix = defaults.creatablePrefix;
@@ -281,7 +282,7 @@
   $: maxReached = max && selectedOptions.length == max;   // == is intentional, if string is provided
   $: availableItems = maxReached
     ? []
-    : filterList(flatItems, disableSifter ? null : $inputValue, multiple ? selectedKeys : false, searchField, sortField, itemConfig);
+    : filterList(flatItems, disableSifter ? null : $inputValue, multiple && filterSelections ? selectedKeys : false, searchField, sortField, itemConfig);
   $: currentListLength = creatable && $inputValue ? availableItems.length : availableItems.length - 1;
   $: listIndex = indexList(availableItems, creatable && $inputValue, itemConfig);
   $: {

--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -419,7 +419,14 @@
    */
   function selectOption(opt) { 
     if (!opt || (multiple && maxReached)) return false;
-    if (selectedKeys.has(opt[currentValueField])) return;
+    if (selectedKeys.has(opt[currentValueField])) {
+      if (!hideSelections || !multiple) return;
+
+      if (hideSelections && multiple) {
+        deselectOption(opt);
+        return;
+      }
+    }
 
     if (typeof opt === 'string') {
       if (!creatable) return;

--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -63,6 +63,7 @@
   export let collapseSelection = defaults.collapseSelection;
   export let alwaysCollapsed = defaults.alwaysCollapsed;
   export let filterSelections = defaults.filterSelections;
+  export let hideSelections = defaults.hideSelections;
   // creating
   export let creatable = defaults.creatable;
   export let creatablePrefix = defaults.creatablePrefix;
@@ -709,7 +710,7 @@
     </slot>
   </Control>
   <Dropdown bind:this={refDropdown} renderer={itemRenderer} {disableHighlight} {creatable} {maxReached} {alreadyCreated}
-    {virtualList} {vlHeight} {vlItemSize} lazyDropdown={virtualList || lazyDropdown} {multiple}
+    {virtualList} {vlHeight} {vlItemSize} lazyDropdown={virtualList || lazyDropdown} {multiple} {hideSelections}
     dropdownIndex={dropdownActiveIndex}
     items={availableItems} {listIndex}
     inputValue={dropdownInputValue} {hasDropdownOpened} {listMessage} {disabledField} createLabel={_i18n.createRowLabel}

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -26,6 +26,7 @@
   export let metaKey;
   export let itemComponent;
   export let selection = null;
+  export let hideSelections;
 
   export function scrollIntoView(params) {
     if (virtualList) return;
@@ -171,7 +172,7 @@
 <div class="sv-dropdown" class:is-virtual={virtualList} aria-expanded={$hasDropdownOpened}
   on:mousedown|preventDefault
 >
-  {#if selection}
+  {#if selection && !hideSelections}
   <div class="sv-content has-multiSelection alwaysCollapsed-selection">
     {#each selection as opt, i (i)}
       <svelte:component this={itemComponent} formatter={renderer} item={opt} isSelected={true} on:deselect isMultiple={multiple} {inputValue}/>

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -24,6 +24,7 @@ const settings = {
   collapseSelection: false, // enable collapsible multiple selection
   alwaysCollapsed: false,
   filterSelections: true,
+  hideSelections: false,
   // create
   creatable: false,
   creatablePrefix: '*',

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -23,6 +23,7 @@ const settings = {
   max: 0,
   collapseSelection: false, // enable collapsible multiple selection
   alwaysCollapsed: false,
+  filterSelections: true,
   // create
   creatable: false,
   creatablePrefix: '*',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
   for (let i = 1; i <= items; i++) {
     options.push({id: i, text: `Item #${i}`});
   }
+  let values = []
 </script>
 
 <div class="container">
@@ -13,9 +14,10 @@
 </div>
 
 <div class="container">
-  <Svelecte {options} filterSelections={false} multiple value={[3,7]} clearable />
+  <Svelecte {options} filterSelections={false} hideSelections multiple bind:value={values} clearable />
 </div>
 
+<span>{values}</span>
 <style>
   .container {
     width: 492px;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,10 @@
   <Svelecte {options} multiple value={[3,7]} clearable />
 </div>
 
+<div class="container">
+  <Svelecte {options} filterSelections={false} multiple value={[3,7]} clearable />
+</div>
+
 <style>
   .container {
     width: 492px;

--- a/src/routes/checkboxes/+page.svelte
+++ b/src/routes/checkboxes/+page.svelte
@@ -1,0 +1,45 @@
+<script>
+  import Svelecte from "$lib/Svelecte.svelte";
+
+  const items = 10;
+  let options = [];
+  for (let i = 1; i <= items; i++) {
+    options.push({ id: i, text: `Item #${i}` });
+  }
+  let values = [];
+
+  const renderer = (item, selected, value) => {
+    return `<label onclick="(e) => e.preventDefault()">
+      <input type="checkbox" ${values.indexOf(item.id) > -1 ? 'checked' : ''}  />
+      <span class="sv-item-content">${item.text}</span>
+    </label>`;
+  }
+</script>
+
+<div class="container" style="width: 160px">
+  <Svelecte 
+    {options} 
+    {renderer}
+    placeholder='Items'
+    i18n={{
+        collapsedSelection: () => 'Items'
+    }}
+    searchable={false}
+    filterSelections={false} 
+    highlightFirstItem={false}
+    hideSelections 
+    collapseSelection 
+    alwaysCollapsed
+    multiple 
+    bind:value={values} 
+/>
+</div>
+
+<span>{values}</span>
+
+<style>
+  .container {
+    width: 492px;
+    margin: 2rem auto;
+  }
+</style>


### PR DESCRIPTION
From what I could tell, there was no canonical way to prevent filtering from the dropdown when `multiple = true`. 

This adds a simple option to disable that behavior. A reason someone might want that ability is to use checkboxes as an on/off display.

I also didn't see a way to hide the selections part. When using a toggle field, like a checkbox, that selections part is way too much clutter. With that, selections also should probably be removed if they are clicked on again.

An example is added how someone might use checkboxes in the dropdown.