### PR TITLE
Adapt options slot - add some properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelecte",
 	"description": "Flexible autocomplete/select component written in Svelte. Massively inspired by Selectize.js. Also usable as custom element (CE)",
-	"version": "4.2.5",
+	"version": "4.2.6",
 	"type": "module",
 	"license": "MIT",
 	"keywords": [

--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -1521,7 +1521,7 @@
                     class:is-selected={opt.$selected}
                     class:is-disabled={opt[disabledField]}
                   >
-                    <slot name="option" item={opt}>
+                    <slot name="option" item={opt} inputValue={input_value} {itemRenderer} selected={opt.$selected}>
                       <div class="sv-item--content">
                         {@html highlightSearch(opt, false, input_value, itemRenderer, disableHighlight) }
                       </div>

--- a/src/routes/rendering/+page.svelte
+++ b/src/routes/rendering/+page.svelte
@@ -204,12 +204,14 @@ If you want to display selected options here as in mentioned issue, check [Migra
 ### &bull; option
 
 ```svelte
-<slot name="option" let:item />
+<slot name="option" let:item let:inputValue let:itemRenderer let:selected/>
 ```
 
 Where:
 
 - `item` is current option in dropdown. To duplicate highlighting functionality you need to use function `highlightSearch` exported from the library.
+- `inputValue` and `itemRenderer` are given to be able to build the original search highlighting.
+- `selected` option states whether this item is selected.
 
 ### &bull; create-row
 


### PR DESCRIPTION
Add some properties to 'option' slot in order to easier inherit the original search highlighting and to retrieve the information whether an item is selected.

Quick background: 
I want to add different icons (depending on the selected state of the item) before the item text but keep the original search highlighting. 

@mskocik we could also introduce another store for that (e.g. `option-icon` including `selected` and `item` properties - I think I would even prefer that because I have some troubles getting the highlightSearch function imported).

What do you think about that?