### PR TITLE
Avoid overzealous clearSelection calls

### DIFF
--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -476,7 +476,7 @@
   function watch_item_props(valueProp, labelProp) {
     if (!is_mounted) return;
 
-    if (valueProp) {
+    if (valueProp && currentValueField !== valueProp) {
       itemConfig.valueField = currentValueField = valueProp;
       // check note in watch_options()
       selectedKeys.size > 0 && clearSelection();


### PR DESCRIPTION
Added the same guard that exists in watch_options to watch_item_props. Without this, a pre-populated selection or any recreation (eg with a `{#key <keyValue>}`)  would clear the selection even when the valueProp value was unchanged.