### PR TITLE
fix css placeholder selector to apply --sv-placeholder-color

### DIFF
--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -1931,7 +1931,7 @@
 
   .sv-input--text {
     outline: none;
-    &:placeholder {
+    &::placeholder {
       color: var(--sv-placeholder-color, #ccccd6);
     }
   }


### PR DESCRIPTION
Simple fix to be able to apply the placeholder color variable