### PR TITLE
feat: added bindable property to pass inputChanges into parent component

### DIFF
--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -120,6 +120,7 @@
    *  controlClass?: string | null;
    *  dropdownClass?: string | null;
    *  optionClass?: string | null;
+   *  onInput?: Function
    * }}
    */
   let {
@@ -198,7 +199,8 @@
     anchor_element = undefined,
     controlClass = undefined,
     dropdownClass = undefined,
-    optionClass = undefined
+    optionClass = undefined,
+    onInput = _inputEvent => {}
   } = $props();
 
   export function focus() {
@@ -1081,6 +1083,7 @@
    * Required for mobile single select to work properly
    */
   function on_input() {
+    onInput?.()
     if (selectedOptions.length === 1 && !multiple) {
       // input_value = '';
     }

--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -120,7 +120,7 @@
    *  controlClass?: string | null;
    *  dropdownClass?: string | null;
    *  optionClass?: string | null;
-   *  onInput?: Function
+   *  typedText?: string | null;
    * }}
    */
   let {
@@ -200,7 +200,7 @@
     controlClass = undefined,
     dropdownClass = undefined,
     optionClass = undefined,
-    onInput = _inputEvent => {}
+    typedText = $bindable('')
   } = $props();
 
   export function focus() {
@@ -1083,7 +1083,6 @@
    * Required for mobile single select to work properly
    */
   function on_input() {
-    onInput?.()
     if (selectedOptions.length === 1 && !multiple) {
       // input_value = '';
     }
@@ -1161,6 +1160,9 @@
   $effect(() => {
     watch_fetch_init(fetch, parentValue)
   });
+  $effect(() => {
+    typedText = input_value
+  })
 
   let listMessage = $state(fetch
     ? (fetch_initOnly


### PR DESCRIPTION
This feature is needed in my application and i think it might be a quite common approach that would give back more control to the Developer using this Library.

It might be that there are complex data-structures that have to be dealt with before sending an fetch request.
an beforeFetch Callback would make the DX worse in my opinion.

making the input_value an bindable prop would also be an valid solution, just tell me what you think would be better

You might want to squash this PR