### PR TITLE
feat: Make `fetchProps` optionally a function

### DIFF
--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -80,7 +80,7 @@
    *  createFilter?: (inputValue: string) => boolean;
    *  createHandler?: (prop: { inputValue: string, valueField: string, labelField: string, prefix: string }) => (Promise<object> | object);
    *  fetch?: string | null;
-   *  fetchProps?: object;
+   *  fetchProps?: object | Function;
    *  fetchMode?: "auto" | "init";
    *  fetchCallback?: Function;
    *  fetchResetOnBlur?: boolean;

--- a/src/lib/Svelecte.svelte
+++ b/src/lib/Svelecte.svelte
@@ -1271,8 +1271,10 @@
         : i18n_actual.fetchBefore;
       return;
     }
-
-    const built = defaults.requestFactory(input_value, { parentValue, url: fetch, initial: initialFetchValue }, fetchProps);
+    const built = defaults.requestFactory(
+      input_value,
+      { parentValue, url: fetch, initial: initialFetchValue },
+      typeof fetchProps === 'function' ? fetchProps() : fetchProps);
     fetch_controller?.abort();
     fetch_controller = built.controller;
     window.fetch(built.request)

--- a/src/lib/utils/fetch.js
+++ b/src/lib/utils/fetch.js
@@ -23,7 +23,7 @@ export function debounce(fn, delay) {
  *  parentValue: string|number|null|undefined,
  *  initial: string|number|string[]|null
  *  }} props
- * @param {RequestInit|object|Function} fetchProps
+ * @param {RequestInit|object} fetchProps
  * @returns {{
  *  request: Request
  *  controller: AbortController
@@ -36,9 +36,6 @@ export function debounce(fn, delay) {
  * @type {RequestFactoryFn}
  */
 export function requestFactory(query, { url, parentValue, initial }, fetchProps) {
-  if (typeof fetchProps === 'function') {
-    fetchProps = fetchProps(); // If fetchProps is a function, call it to get the real values
-  }
   if (parentValue) {
     url = url.replace('[parent]', encodeURIComponent(parentValue));
   }

--- a/src/lib/utils/fetch.js
+++ b/src/lib/utils/fetch.js
@@ -23,7 +23,7 @@ export function debounce(fn, delay) {
  *  parentValue: string|number|null|undefined,
  *  initial: string|number|string[]|null
  *  }} props
- * @param {RequestInit|object} fetchProps
+ * @param {RequestInit|object|Function} fetchProps
  * @returns {{
  *  request: Request
  *  controller: AbortController
@@ -36,6 +36,9 @@ export function debounce(fn, delay) {
  * @type {RequestFactoryFn}
  */
 export function requestFactory(query, { url, parentValue, initial }, fetchProps) {
+  if (typeof fetchProps === 'function') {
+    fetchProps = fetchProps(); // If fetchProps is a function, call it to get the real values
+  }
   if (parentValue) {
     url = url.replace('[parent]', encodeURIComponent(parentValue));
   }

--- a/src/routes/properties/+page.svelte.md
+++ b/src/routes/properties/+page.svelte.md
@@ -42,7 +42,7 @@ delimiter                 | `string`          | `,`         | split inserted tex
 createFilter              | `function`        | `null`      | Function receiving `inputValue` returning `bool` checks if input string is valid or not. If you want to dismiss entered value (ie. prevent item creation), function should return `true`, `false` otherwise.
 createHandler             | `function`        | `null`      | Custom (may be) async function transforming input string to option object. Default returns object with `valueField` and `labelField` properties, where `labelField`'s value is input string prefixed with `creatablePrefix` property.
 fetch                     | `string`          | `null`      | Sets fetch URL. Visit [Remote datasource] form more details
-fetchProps                | `object`          | `null`      | Set options for new fetch [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request)
+fetchProps                |`object`,`function`| `null`      | Set options for new fetch [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request). If assigned as a function, the options will be set from the function's output.
 fetchCallback             | `function`        | `null`      | optional fetch callback
 fetchResetOnBlur          | `bool`            | `true`      | reset previous search results on empty input, related to `resetOnBlur`
 fetchDebounceTime         | `number`          | `300`       | how many miliseconds is request debounced before fetch is executed


### PR DESCRIPTION
Solves #307 

Changes the type of `fetchProps` to be an object or a function. If it's a function it's evaluated at the time of use. For instance:

~~~js
// token will be re-evaluated whenever we create a request
function getFetchProps() {
    return {
        headers: {
            "Authorization": `Bearer ${localStorage.getItem("token") || ""}`
        }
    }
}
~~~

~~~html
<Svelecte fetch={endpoint} fetchProps={getFetchProps} />
~~~